### PR TITLE
Fix refund

### DIFF
--- a/KBotExt/GameTab.h
+++ b/KBotExt/GameTab.h
@@ -410,7 +410,7 @@ public:
 				std::string regionLocale = http->Request("GET", "https://127.0.0.1/riotclient/get_region_locale", "", auth->leagueHeader, "", "", auth->leaguePort);
 				if (reader->parse(regionLocale.c_str(), regionLocale.c_str() + static_cast<int>(regionLocale.length()), &rootLocale, &err))
 				{
-					std::string region = Utils::WstringToString(Utils::StringToWstring(rootLocale["webRegion"].asString()));
+					std::string region = Utils::ToLower(rootLocale["region"].asString());
 					std::string session = http->Request("GET", "https://127.0.0.1/lol-login/v1/session", "", auth->leagueHeader, "", "", auth->leaguePort);
 					if (reader->parse(session.c_str(), session.c_str() + static_cast<int>(session.length()), &rootSession, &err))
 					{

--- a/KBotExt/GameTab.h
+++ b/KBotExt/GameTab.h
@@ -403,28 +403,24 @@ public:
 				Json::CharReaderBuilder builder;
 				const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
 				JSONCPP_STRING err;
-				Json::Value rootLocale;
 				Json::Value rootSession;
 				Json::Value rootPurchaseHistory;
 
-				std::string regionLocale = http->Request("GET", "https://127.0.0.1/riotclient/get_region_locale", "", auth->leagueHeader, "", "", auth->leaguePort);
-				if (reader->parse(regionLocale.c_str(), regionLocale.c_str() + static_cast<int>(regionLocale.length()), &rootLocale, &err))
+				std::string storeUrl = http->Request("GET", "https://127.0.0.1/lol-store/v1/getStoreUrl", "", auth->leagueHeader, "", "", auth->leaguePort);
+				storeUrl = storeUrl.erase(0, 1).erase(storeUrl.size() - 1);
+				std::string session = http->Request("GET", "https://127.0.0.1/lol-login/v1/session", "", auth->leagueHeader, "", "", auth->leaguePort);
+				if (reader->parse(session.c_str(), session.c_str() + static_cast<int>(session.length()), &rootSession, &err))
 				{
-					std::string region = Utils::ToLower(rootLocale["region"].asString());
-					std::string session = http->Request("GET", "https://127.0.0.1/lol-login/v1/session", "", auth->leagueHeader, "", "", auth->leaguePort);
-					if (reader->parse(session.c_str(), session.c_str() + static_cast<int>(session.length()), &rootSession, &err))
+					std::string accountId = rootSession["accountId"].asString();
+					std::string idToken = rootSession["idToken"].asString();
+					std::string authorizationHeader = "Authorization: Bearer " + idToken + "\r\n" +
+						"Accept: application/json" + "\r\n" +
+						"Content-Type: application/json" + "\r\n";
+					std::string purchaseHistory = http->Request("GET", storeUrl+"/storefront/v3/history/purchase", "", authorizationHeader, "", "");
+					if (reader->parse(purchaseHistory.c_str(), purchaseHistory.c_str() + static_cast<int>(purchaseHistory.length()), &rootPurchaseHistory, &err))
 					{
-						std::string accountId = rootSession["accountId"].asString();
-						std::string idToken = rootSession["idToken"].asString();
-						std::string authorizationHeader = "Authorization: Bearer " + idToken + "\r\n" +
-							"Accept: application/json" + "\r\n" +
-							"Content-Type: application/json" + "\r\n";
-						std::string purchaseHistory = http->Request("GET", "https://" + region + ".store.leagueoflegends.com/storefront/v3/history/purchase", "", authorizationHeader, "", "");
-						if (reader->parse(purchaseHistory.c_str(), purchaseHistory.c_str() + static_cast<int>(purchaseHistory.length()), &rootPurchaseHistory, &err))
-						{
-							std::string transactionId = rootPurchaseHistory["transactions"][0]["transactionId"].asString();
-							result = http->Request("POST", "https://" + region + ".store.leagueoflegends.com/storefront/v3/refund", "{\"accountId\":" + accountId + ",\"transactionId\":\"" + transactionId + "\",\"inventoryType\":\"CHAMPION\",\"language\":\"EN_US\"}", authorizationHeader, "", "");
-						}
+						std::string transactionId = rootPurchaseHistory["transactions"][0]["transactionId"].asString();
+						result = http->Request("POST", storeUrl+"/storefront/v3/refund", "{\"accountId\":" + accountId + ",\"transactionId\":\"" + transactionId + "\",\"inventoryType\":\"CHAMPION\",\"language\":\"EN_US\"}", authorizationHeader, "", "");
 					}
 				}
 			}


### PR DESCRIPTION
### Content:
Fixed refund not working properly in some regions and in Garena servers (#51)

### More info:
* [GET] `/riotclient/get_region_locale` endpoint responds differently on Garena than the other servers.
On Garena servers `webRegion` field seems to be empty.
* Some servers have a final number in the region field (e.g. `LA1`), that number is a part of the URL required for making calls to the store endpoints (e.g. [lan.store.leagueoflegends.com](https://lan.store.leagueoflegends.com) does not works but instead [la1.store.leagueoflegends.com](https://la1.store.leagueoflegends.com) works fine).

Then take the value of `region` instead of `webRegion` should be the solution to the problem.
I tested the change on various server, it seems to work without any problem.

### Response examples:
1. The `region` and `webRegion` fields are equals and not empty:
```json
{
  "locale" : "en_US",
  "region" : "NA",
  "webLanguage" : "en",
  "webRegion" : "na"
}
```
```json
{
  "locale" : "it_IT",
  "region" : "EUW",
  "webLanguage" : "it",
  "webRegion" : "euw"
}
```
```json
{
  "locale" : "tr_TR",
  "region" : "TR",
  "webLanguage" : "tr",
  "webRegion" : "tr"
}
```
2. The `region` and `webRegion` fields are different (`region` field with final number) and not empty:
```json
{
  "locale" : "es_MX",
  "region" : "LA1",
  "webLanguage" : "es",
  "webRegion" : "lan"
}
```
3. `webRegion` field is empty (Garena):
```json
{
  "locale" : "en_SG",
  "region" : "SG",
  "webLanguage" : "en",
  "webRegion" : ""
}
```